### PR TITLE
tools: fix vif-netmap init issue of order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,7 @@ ifeq ($(NETMAP), yes)
 endif
 
 # sources and objects
-NUSE_SRC=\
-nuse-fiber.c nuse-vif.c nuse-hostcalls.c nuse-config.c \
-nuse-vif-rawsock.c nuse-vif-tap.c nuse-vif-pipe.c nuse-glue.c nuse.c
-
+NUSE_SRC=
 ifeq "$(DPDK)" "yes"
 	include Makefile.dpdk
 	DPDK_LDFLAGS=-L$(RTE_SDK)/$(RTE_TARGET)/lib
@@ -48,6 +45,10 @@ ifeq "$(NETMAP)" "yes"
 	NUSE_SRC+=nuse-vif-netmap.c
 	CFLAGS+= -Inetmap/sys
 endif
+
+NUSE_SRC+=\
+nuse-fiber.c nuse-vif.c nuse-hostcalls.c nuse-config.c \
+nuse-vif-rawsock.c nuse-vif-tap.c nuse-vif-pipe.c nuse-glue.c nuse.c
 
 
 SIM_SRC=sim.c

--- a/nuse-vif-netmap.c
+++ b/nuse-vif-netmap.c
@@ -63,7 +63,7 @@ netmap_get_nifp(const char *ifname, struct netmap_if **_nifp)
 
 	fd = open("/dev/netmap", O_RDWR);
 	if (fd < 0) {
-		printf("unable to open /dev/netmap");
+		printf("unable to open /dev/netmap\n");
 		return 0;
 	}
 
@@ -74,7 +74,7 @@ netmap_get_nifp(const char *ifname, struct netmap_if **_nifp)
 	nmr.nr_flags |= NR_REG_ALL_NIC;
 
 	if (ioctl(fd, NIOCREGIF, &nmr) < 0) {
-		printf("unable to register interface %s", ifname);
+		printf("unable to register interface %s\n", ifname);
 		return 0;
 	}
 
@@ -86,7 +86,7 @@ netmap_get_nifp(const char *ifname, struct netmap_if **_nifp)
 	mem = mmap(NULL, nmr.nr_memsize,
 		   PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 	if (mem == MAP_FAILED) {
-		printf("unable to mmap");
+		printf("unable to mmap\n");
 		return 0;
 	}
 


### PR DESCRIPTION
initializtion order of vif instance depends on the order of linking of
libnuse-linux.so. nuse-vif-netmap.o was linked _after_ nuse.o, and
nuse_vif_netmap_init() wasn't called before nuse_init. This brought an
core dump as issue #15 reported.

Signed-off-by: Hajime Tazaki <tazaki@sfc.wide.ad.jp>